### PR TITLE
fixed minor properties in API ontology

### DIFF
--- a/working_draft/API/ONE-Record-API-Ontology.ttl
+++ b/working_draft/API/ONE-Record-API-Ontology.ttl
@@ -469,7 +469,7 @@ owl:minQualifiedCardinality rdf:type owl:AnnotationProperty .
 
 
 ###  https://onerecord.iata.org/ns/api#hasLogisticsObjectType
-:hasLogisticsObjectType rdf:type owl:ObjectProperty ;
+:hasLogisticsObjectType rdf:type owl:DatatypeProperty ;
                         rdfs:domain :Notification ;
                         rdfs:range xsd:anyURI ;
                         rdfs:comment "The type of cargo:LogisticsObject in the notification e.g. https://onerecord.iata.org/ns/cargo#Piece" ;
@@ -807,7 +807,7 @@ owl:minQualifiedCardinality rdf:type owl:AnnotationProperty .
                               [ rdf:type owl:Restriction ;
                                 owl:onProperty :hasLogisticsObjectType ;
                                 owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-                                owl:onClass xsd:anyURI
+                                owl:onDataRange xsd:anyURI
                               ] ,
                               [ rdf:type owl:Restriction ;
                                 owl:onProperty :isTriggeredBy ;
@@ -977,6 +977,10 @@ owl:minQualifiedCardinality rdf:type owl:AnnotationProperty .
                                      owl:onClass cargo:Organization
                                    ] ,
                                    [ rdf:type owl:Restriction ;
+                                     owl:onProperty :hasDataHolder ;
+                                     owl:allValuesFrom cargo:Organization
+                                   ] ,
+                                   [ rdf:type owl:Restriction ;
                                      owl:onProperty :hasSupportedEncoding ;
                                      owl:allValuesFrom xsd:string
                                    ] ,
@@ -1024,6 +1028,10 @@ owl:minQualifiedCardinality rdf:type owl:AnnotationProperty .
                                 owl:onProperty :hasSubscriber ;
                                 owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
                                 owl:onClass cargo:Organization
+                              ] ,
+                              [ rdf:type owl:Restriction ;
+                                owl:onProperty :hasSubscriber ;
+                                owl:allValuesFrom cargo:Organization
                               ] ,
                               [ rdf:type owl:Restriction ;
                                 owl:onProperty :hasTopicType ;


### PR DESCRIPTION
- changed rdf:type of api:hasLogisticsObjectType from owl:ObjectProperty to owl:DatatypeProperty
- added owl:allValuesFrom restriction to api:hasDataHolder and api:hasSubscriber to make type explicit